### PR TITLE
Fixed setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 {
     "gruvw/strudel.nvim",
     config = function()
-            local strudel = require("strudel")
-            strudel.setup()
+            require("strudel").setup()
     end,
     build = "npm install"
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
     "gruvw/strudel.nvim",
-    cmd = "StrudelLaunch",
+    config = function()
+            local strudel = require("strudel")
+            strudel.setup()
+    end,
     build = "npm install"
 }
 ```


### PR DESCRIPTION
Problem:

- The given instructions to install the plugin in `lazy` didn't work, the `StrudelLaunch` command wouldn't run.

Solution:

- Changed the README to include the setup function when launching, enabling the command