### PR TITLE
feat: remove Chrome warning banner after StrudelLaunch

### DIFF
--- a/js/launch.js
+++ b/js/launch.js
@@ -283,7 +283,10 @@ async function handleEvent(message) {
             headless: userConfig.isHeadless,
             defaultViewport: null,
             userDataDir: userConfig.userDataDir,
-            ignoreDefaultArgs: ["--mute-audio"],
+            ignoreDefaultArgs: [
+                "--mute-audio",
+                "--enable-automation",
+            ],
             args: [
                 `--app=${STRUDEL_URL}`,
                 "--autoplay-policy=no-user-gesture-required",


### PR DESCRIPTION
This PR removes the indication that the browser is controlled by automation/test software by ignoring a default Puppeteer command line argument named `--enable-automation`.

As stated in https://peter.sh/experiments/chromium-command-line-switches/, this command line argument purely affects the automation indication and nothing else. Hence, this PR does not change any existing functionality of strudel.nvim.