### PR TITLE
Change example build command to `npm ci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   "gruvw/strudel.nvim",
-  build = "npm install",
+  build = "npm ci",
   config = function()
     require("strudel").setup()
   end,


### PR DESCRIPTION
This plugin in awesome thanks! 👏🏽

When installing with Lazy using `npm install` will possibly change the package.json or package-lock.json file and therefore Lazy will complain about having local changes stored in your plugin folder.

Using `npm ci` ensures that no local changes will be made to package.json or package-lock.json when updating the plugin 😄